### PR TITLE
add rotation only and fix first two frames

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -478,6 +478,8 @@ void OptionManager::AddBundleAdjustmentOptions() {
                               &bundle_adjustment->min_num_images_gpu_solver);
   AddAndRegisterDefaultOption("BundleAdjustment.refine_rotation_only",
                             &bundle_adjustment->refine_rotation_only);
+  AddAndRegisterDefaultOption("BundleAdjustment.fix_coord_system",
+                            &bundle_adjustment->fix_coord_system);
   AddAndRegisterDefaultOption(
       "BundleAdjustment.min_num_residuals_for_cpu_multi_threading",
       &bundle_adjustment->min_num_residuals_for_cpu_multi_threading);

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -476,6 +476,8 @@ void OptionManager::AddBundleAdjustmentOptions() {
                               &bundle_adjustment->gpu_index);
   AddAndRegisterDefaultOption("BundleAdjustment.min_num_images_gpu_solver",
                               &bundle_adjustment->min_num_images_gpu_solver);
+  AddAndRegisterDefaultOption("BundleAdjustment.refine_rotation_only",
+                            &bundle_adjustment->refine_rotation_only);
   AddAndRegisterDefaultOption(
       "BundleAdjustment.min_num_residuals_for_cpu_multi_threading",
       &bundle_adjustment->min_num_residuals_for_cpu_multi_threading);

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -326,7 +326,9 @@ void BundleAdjuster::SetUpProblem(Reconstruction* reconstruction,
     AddPointToProblem(point3D_id, reconstruction, loss_function);
   }
 
-  AddCoordinateSystemConstraint(reconstruction);
+  if (options_.fix_coord_system){
+    AddCoordinateSystemConstraint(reconstruction);
+  }
   ParameterizeCameras(reconstruction);
   ParameterizePoints(reconstruction);
 }

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -64,6 +64,9 @@ struct BundleAdjustmentOptions {
   // Whether to refine the rotation only.
   bool refine_rotation_only = false;
 
+  // Whether to fix the coordinate system.
+  bool fix_coord_system = false;
+
   // Whether to print a final summary.
   bool print_summary = true;
 

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -61,6 +61,9 @@ struct BundleAdjustmentOptions {
   // Whether to refine the extrinsic parameter group.
   bool refine_extrinsics = true;
 
+  // Whether to refine the rotation only.
+  bool refine_rotation_only = false;
+
   // Whether to print a final summary.
   bool print_summary = true;
 
@@ -205,6 +208,21 @@ class BundleAdjuster {
   const ceres::Solver::Summary& Summary() const;
 
  private:
+  struct DistanceConstraint {
+    DistanceConstraint(double distance) : distance_(distance) {}
+
+    template <typename T>
+    bool operator()(const T* const p1, const T* const p2, T* residual) const {
+      residual[0] = distance_ - sqrt(
+          (p1[0] - p2[0]) * (p1[0] - p2[0]) +
+          (p1[1] - p2[1]) * (p1[1] - p2[1]) +
+          (p1[2] - p2[2]) * (p1[2] - p2[2]));
+      return true;
+    }
+
+    const double distance_;
+  };
+  void AddCoordinateSystemConstraint(Reconstruction* reconstruction);
   void AddImageToProblem(image_t image_id,
                          Reconstruction* reconstruction,
                          ceres::LossFunction* loss_function);

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -113,6 +113,8 @@ void BindBundleAdjuster(py::module& m) {
       .def("has_constant_cam_intrinsics",
            &BACfg::HasConstantCamIntrinsics,
            "camera_id"_a)
+      .def_readwrite("refine_rotation_only", &BAOpts::refine_rotation_only,
+               "Whether to only refine rotation while keeping translation constant")
       .def("set_constant_cam_pose", &BACfg::SetConstantCamPose, "image_id"_a)
       .def("set_variable_cam_pose", &BACfg::SetVariableCamPose, "image_id"_a)
       .def("has_constant_cam_pose", &BACfg::HasConstantCamPose, "image_id"_a)

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -115,6 +115,8 @@ void BindBundleAdjuster(py::module& m) {
            "camera_id"_a)
       .def_readwrite("refine_rotation_only", &BAOpts::refine_rotation_only,
                "Whether to only refine rotation while keeping translation constant")
+     .def_readwrite("fix_coord_system", &BAOpts::fix_coord_system,
+               "Whether to fix scale and origin of the camera motion")
       .def("set_constant_cam_pose", &BACfg::SetConstantCamPose, "image_id"_a)
       .def("set_variable_cam_pose", &BACfg::SetVariableCamPose, "image_id"_a)
       .def("has_constant_cam_pose", &BACfg::HasConstantCamPose, "image_id"_a)


### PR DESCRIPTION
Summary:

- add a new flag "rotation only" to bundle adjuster to run bundle adjustment with fixed translation
- set default to freeze first frame and distance between first two frames