### PR TITLE
add sequential pairwise distance constraint to ba

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -480,8 +480,14 @@ void OptionManager::AddBundleAdjustmentOptions() {
                             &bundle_adjustment->refine_rotation_only);
   AddAndRegisterDefaultOption("BundleAdjustment.fix_coord_system",
                             &bundle_adjustment->fix_coord_system);
-  AddAndRegisterDefaultOption("BundleAdjustment.fix_global_coord_system",
-                            &bundle_adjustment->fix_global_coord_system);
+  AddAndRegisterDefaultOption("BundleAdjustment.sequential_pairwise_constraint",
+                            &bundle_adjustment->sequential_pairwise_constraint);
+  AddAndRegisterDefaultOption("BundleAdjustment.sequential_translation_constraint",
+                            &bundle_adjustment->sequential_translation_constraint);
+  AddAndRegisterDefaultOption("BundleAdjustment.sequential_translation_weight",
+                            &bundle_adjustment->sequential_translation_weight);
+  AddAndRegisterDefaultOption("BundleAdjustment.sequential_rotation_weight",
+                            &bundle_adjustment->sequential_rotation_weight);
   AddAndRegisterDefaultOption("BundleAdjustment.save_path",
                               &bundle_adjustment->save_path);
   AddAndRegisterDefaultOption("BundleAdjustment.current_iteration",

--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -480,10 +480,8 @@ void OptionManager::AddBundleAdjustmentOptions() {
                             &bundle_adjustment->refine_rotation_only);
   AddAndRegisterDefaultOption("BundleAdjustment.fix_coord_system",
                             &bundle_adjustment->fix_coord_system);
-  AddAndRegisterDefaultOption("BundleAdjustment.save_path",
-                              &bundle_adjustment->save_path);
-  AddAndRegisterDefaultOption("BundleAdjustment.current_iteration",
-                              &bundle_adjustment->current_iteration);
+  AddAndRegisterDefaultOption("BundleAdjustment.fix_global_coord_system",
+                            &bundle_adjustment->fix_global_coord_system);
   AddAndRegisterDefaultOption("BundleAdjustment.save_path",
                               &bundle_adjustment->save_path);
   AddAndRegisterDefaultOption("BundleAdjustment.current_iteration",

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -395,12 +395,14 @@ void BundleAdjuster::AddSequentialTranslationConstraint(Reconstruction* reconstr
 
         // Convert camera-from-world to world-from-camera transformations
         const Rigid3d world_from_cam1(
-            image1.CamFromWorld().rotation.inverse(),
-            -(image1.CamFromWorld().rotation.inverse() * image1.CamFromWorld().translation));
+            image1.CamFromWorld().rotation.inverse().normalized(),
+            -(image1.CamFromWorld().rotation.inverse().normalized() * 
+              image1.CamFromWorld().translation));
         
         const Rigid3d world_from_cam2(
-            image2.CamFromWorld().rotation.inverse(),
-            -(image2.CamFromWorld().rotation.inverse() * image2.CamFromWorld().translation));
+            image2.CamFromWorld().rotation.inverse().normalized(),
+            -(image2.CamFromWorld().rotation.inverse().normalized() * 
+              image2.CamFromWorld().translation));
 
         // Calculate initial camera centers (in world coordinates)
         const Eigen::Vector3d center1 = world_from_cam1.translation;
@@ -551,24 +553,31 @@ void BundleAdjuster::AddSequentialPairwisePoseConstraint(Reconstruction* reconst
     Image& image1 = reconstruction->Image(sorted_image_ids[i]);
     Image& image2 = reconstruction->Image(sorted_image_ids[i + 1]);
 
+    // Normalize quaternions before any operations
+    image1.CamFromWorld().rotation.normalize();
+    image2.CamFromWorld().rotation.normalize();
+
     // Convert camera-from-world to world-from-camera transformations
     const Rigid3d world_from_cam1(
-        image1.CamFromWorld().rotation.inverse(),
-        -(image1.CamFromWorld().rotation.inverse() * image1.CamFromWorld().translation));
+        image1.CamFromWorld().rotation.inverse().normalized(),
+        -(image1.CamFromWorld().rotation.inverse().normalized() * 
+          image1.CamFromWorld().translation));
     
     const Rigid3d world_from_cam2(
-        image2.CamFromWorld().rotation.inverse(),
-        -(image2.CamFromWorld().rotation.inverse() * image2.CamFromWorld().translation));
+        image2.CamFromWorld().rotation.inverse().normalized(),
+        -(image2.CamFromWorld().rotation.inverse().normalized() * 
+          image2.CamFromWorld().translation));
 
     // Calculate initial camera centers (in world coordinates)
     const Eigen::Vector3d center1 = world_from_cam1.translation;
     const Eigen::Vector3d center2 = world_from_cam2.translation;
 
     // Calculate initial relative transformation between cameras
-    // relative_rotation = R2^(-1) * R1 where R1, R2 are world-from-camera rotations
+    // Ensure all quaternion operations maintain normalization
     const Eigen::Vector3d initial_translation_diff = center2 - center1;
     const Eigen::Quaterniond initial_relative_rotation = 
-        image2.CamFromWorld().rotation * image1.CamFromWorld().rotation.inverse();
+        (image2.CamFromWorld().rotation * 
+         image1.CamFromWorld().rotation.inverse()).normalized();
 
     // Only add constraints if both cameras' parameters are in the problem
     double* rotation1 = image1.CamFromWorld().rotation.coeffs().data();
@@ -786,10 +795,15 @@ void BundleAdjuster::AddPointToProblem(const point3D_t point3D_id,
 
 void BundleAdjuster::ParameterizeCameras(Reconstruction* reconstruction) {
   const bool constant_camera = !options_.refine_focal_length &&
-                               !options_.refine_principal_point &&
-                               !options_.refine_extra_params;
+                             !options_.refine_principal_point &&
+                             !options_.refine_extra_params;
   for (const camera_t camera_id : camera_ids_) {
     Camera& camera = reconstruction->Camera(camera_id);
+
+    // Skip if parameter block is not in the problem
+    if (!problem_->HasParameterBlock(camera.params.data())) {
+      continue;
+    }
 
     if (constant_camera || config_.HasConstantCamIntrinsics(camera_id)) {
       problem_->SetParameterBlockConstant(camera.params.data());
@@ -813,11 +827,12 @@ void BundleAdjuster::ParameterizeCameras(Reconstruction* reconstruction) {
             const_camera_params.end(), params_idxs.begin(), params_idxs.end());
       }
 
-      if (const_camera_params.size() > 0) {
+      if (const_camera_params.size() > 0 && 
+          !problem_->GetParameterization(camera.params.data())) {
         SetSubsetManifold(static_cast<int>(camera.params.size()),
-                          const_camera_params,
-                          problem_.get(),
-                          camera.params.data());
+                         const_camera_params,
+                         problem_.get(),
+                         camera.params.data());
       }
     }
   }

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -373,6 +373,60 @@ void BundleAdjuster::AddPositionPriorConstraints(Reconstruction* reconstruction)
     }
 }
 
+void BundleAdjuster::AddSequentialTranslationConstraint(Reconstruction* reconstruction) {
+    if (!options_.sequential_translation_constraint) {
+        return;
+    }
+
+    // Create a vector of sorted image IDs to ensure sequential ordering
+    std::vector<image_t> sorted_image_ids(config_.Images().begin(), config_.Images().end());
+    std::sort(sorted_image_ids.begin(), sorted_image_ids.end());
+
+    // Add constraints between sequential camera pairs
+    for (size_t i = 0; i < sorted_image_ids.size() - 1; i++) {
+        Image& image1 = reconstruction->Image(sorted_image_ids[i]);
+        Image& image2 = reconstruction->Image(sorted_image_ids[i + 1]);
+
+        // Skip if either camera pose is constant
+        if (config_.HasConstantCamPose(sorted_image_ids[i]) || 
+            config_.HasConstantCamPose(sorted_image_ids[i + 1])) {
+            continue;
+        }
+
+        // Convert camera-from-world to world-from-camera transformations
+        const Rigid3d world_from_cam1(
+            image1.CamFromWorld().rotation.inverse(),
+            -(image1.CamFromWorld().rotation.inverse() * image1.CamFromWorld().translation));
+        
+        const Rigid3d world_from_cam2(
+            image2.CamFromWorld().rotation.inverse(),
+            -(image2.CamFromWorld().rotation.inverse() * image2.CamFromWorld().translation));
+
+        // Calculate initial camera centers (in world coordinates)
+        const Eigen::Vector3d center1 = world_from_cam1.translation;
+        const Eigen::Vector3d center2 = world_from_cam2.translation;
+
+        // Calculate initial translation difference between consecutive cameras
+        const Eigen::Vector3d initial_translation_diff = center2 - center1;
+
+        // Only add constraints if both cameras' parameters are in the problem
+        double* translation1 = image1.CamFromWorld().translation.data();
+        double* translation2 = image2.CamFromWorld().translation.data();
+
+        if (problem_->HasParameterBlock(translation1) && 
+            problem_->HasParameterBlock(translation2)) {
+            // Add translation difference constraint
+            problem_->AddResidualBlock(
+                new ceres::AutoDiffCostFunction<VectorDifferenceConstraint, 3, 3, 3>(
+                    new VectorDifferenceConstraint(initial_translation_diff, 
+                                                 options_.sequential_translation_weight)),
+                new ceres::HuberLoss(1.0),
+                translation1,
+                translation2);
+        }
+    }
+}
+
 const BundleAdjustmentOptions& BundleAdjuster::Options() const {
   return options_;
 }
@@ -413,8 +467,12 @@ void BundleAdjuster::SetUpProblem(Reconstruction* reconstruction,
     AddCoordinateSystemConstraint(reconstruction);
   }
 
-  if (options_.fix_global_coord_system){
-    AddGlobalCoordinateSystemConstraint(reconstruction);
+  if (options_.sequential_pairwise_constraint) {
+    AddSequentialPairwisePoseConstraint(reconstruction);
+  }
+
+  if (options_.sequential_translation_constraint) {
+    AddSequentialTranslationConstraint(reconstruction);
   }
 
   if (options_.use_position_prior) {
@@ -466,7 +524,7 @@ void BundleAdjuster::AddCoordinateSystemConstraint(Reconstruction* reconstructio
   }
 }
 
-void BundleAdjuster::AddGlobalCoordinateSystemConstraint(Reconstruction* reconstruction) {
+void BundleAdjuster::AddSequentialPairwisePoseConstraint(Reconstruction* reconstruction) {
   // Choose a reference image (e.g., the first image)
   const image_t reference_image_id = *config_.Images().begin();
   Image& reference_image = reconstruction->Image(reference_image_id);
@@ -488,30 +546,56 @@ void BundleAdjuster::AddGlobalCoordinateSystemConstraint(Reconstruction* reconst
   std::vector<image_t> sorted_image_ids(config_.Images().begin(), config_.Images().end());
   std::sort(sorted_image_ids.begin(), sorted_image_ids.end());
 
-  // Add distance constraints between sequential camera pairs
+  // Add constraints between sequential camera pairs
   for (size_t i = 0; i < sorted_image_ids.size() - 1; i++) {
     Image& image1 = reconstruction->Image(sorted_image_ids[i]);
     Image& image2 = reconstruction->Image(sorted_image_ids[i + 1]);
 
-    // Get camera centers
-    const Eigen::Vector3d center1 = image1.CamFromWorld().translation;
-    const Eigen::Vector3d center2 = image2.CamFromWorld().translation;
+    // Convert camera-from-world to world-from-camera transformations
+    const Rigid3d world_from_cam1(
+        image1.CamFromWorld().rotation.inverse(),
+        -(image1.CamFromWorld().rotation.inverse() * image1.CamFromWorld().translation));
+    
+    const Rigid3d world_from_cam2(
+        image2.CamFromWorld().rotation.inverse(),
+        -(image2.CamFromWorld().rotation.inverse() * image2.CamFromWorld().translation));
 
-    // Calculate initial distance between camera centers
-    double initial_distance = (center2 - center1).norm();
+    // Calculate initial camera centers (in world coordinates)
+    const Eigen::Vector3d center1 = world_from_cam1.translation;
+    const Eigen::Vector3d center2 = world_from_cam2.translation;
 
-    // Only add the constraint if both camera positions are in the problem
+    // Calculate initial relative transformation between cameras
+    // relative_rotation = R2^(-1) * R1 where R1, R2 are world-from-camera rotations
+    const Eigen::Vector3d initial_translation_diff = center2 - center1;
+    const Eigen::Quaterniond initial_relative_rotation = 
+        image2.CamFromWorld().rotation * image1.CamFromWorld().rotation.inverse();
+
+    // Only add constraints if both cameras' parameters are in the problem
+    double* rotation1 = image1.CamFromWorld().rotation.coeffs().data();
+    double* rotation2 = image2.CamFromWorld().rotation.coeffs().data();
     double* translation1 = image1.CamFromWorld().translation.data();
     double* translation2 = image2.CamFromWorld().translation.data();
 
     if (problem_->HasParameterBlock(translation1) && 
         problem_->HasParameterBlock(translation2)) {
+      // Add translation difference constraint
       problem_->AddResidualBlock(
-          new ceres::AutoDiffCostFunction<DistanceConstraint, 1, 3, 3>(
-              new DistanceConstraint(initial_distance)),
-          new ceres::HuberLoss(1.0),  // Add robust loss function to handle noise
+          new ceres::AutoDiffCostFunction<VectorDifferenceConstraint, 3, 3, 3>(
+              new VectorDifferenceConstraint(initial_translation_diff, options_.sequential_translation_weight)),
+          new ceres::HuberLoss(1.0),
           translation1,
           translation2);
+    }
+
+    if (problem_->HasParameterBlock(rotation1) && 
+        problem_->HasParameterBlock(rotation2)) {
+      // Add relative rotation constraint
+      problem_->AddResidualBlock(
+          new ceres::AutoDiffCostFunction<RelativeRotationConstraint, 3, 4, 4>(
+              new RelativeRotationConstraint(initial_relative_rotation)),
+          new ceres::HuberLoss(1.0),
+          rotation1,
+          rotation2);
     }
   }
 }

--- a/src/colmap/estimators/bundle_adjustment.cc
+++ b/src/colmap/estimators/bundle_adjustment.cc
@@ -413,6 +413,10 @@ void BundleAdjuster::SetUpProblem(Reconstruction* reconstruction,
     AddCoordinateSystemConstraint(reconstruction);
   }
 
+  if (options_.fix_global_coord_system){
+    AddGlobalCoordinateSystemConstraint(reconstruction);
+  }
+
   if (options_.use_position_prior) {
     AddPositionPriorConstraints(reconstruction);
   }
@@ -462,6 +466,55 @@ void BundleAdjuster::AddCoordinateSystemConstraint(Reconstruction* reconstructio
   }
 }
 
+void BundleAdjuster::AddGlobalCoordinateSystemConstraint(Reconstruction* reconstruction) {
+  // Choose a reference image (e.g., the first image)
+  const image_t reference_image_id = *config_.Images().begin();
+  Image& reference_image = reconstruction->Image(reference_image_id);
+
+  // Check if the parameters are already in the problem
+  double* rotation_data = reference_image.CamFromWorld().rotation.coeffs().data();
+  double* translation_data = reference_image.CamFromWorld().translation.data();
+
+  // Only set parameters constant if they exist in the problem
+  if (problem_->HasParameterBlock(rotation_data)) {
+    problem_->SetParameterBlockConstant(rotation_data);
+  }
+  
+  if (problem_->HasParameterBlock(translation_data)) {
+    problem_->SetParameterBlockConstant(translation_data);
+  }
+
+  // Create a vector of sorted image IDs to ensure sequential ordering
+  std::vector<image_t> sorted_image_ids(config_.Images().begin(), config_.Images().end());
+  std::sort(sorted_image_ids.begin(), sorted_image_ids.end());
+
+  // Add distance constraints between sequential camera pairs
+  for (size_t i = 0; i < sorted_image_ids.size() - 1; i++) {
+    Image& image1 = reconstruction->Image(sorted_image_ids[i]);
+    Image& image2 = reconstruction->Image(sorted_image_ids[i + 1]);
+
+    // Get camera centers
+    const Eigen::Vector3d center1 = image1.CamFromWorld().translation;
+    const Eigen::Vector3d center2 = image2.CamFromWorld().translation;
+
+    // Calculate initial distance between camera centers
+    double initial_distance = (center2 - center1).norm();
+
+    // Only add the constraint if both camera positions are in the problem
+    double* translation1 = image1.CamFromWorld().translation.data();
+    double* translation2 = image2.CamFromWorld().translation.data();
+
+    if (problem_->HasParameterBlock(translation1) && 
+        problem_->HasParameterBlock(translation2)) {
+      problem_->AddResidualBlock(
+          new ceres::AutoDiffCostFunction<DistanceConstraint, 1, 3, 3>(
+              new DistanceConstraint(initial_distance)),
+          new ceres::HuberLoss(1.0),  // Add robust loss function to handle noise
+          translation1,
+          translation2);
+    }
+  }
+}
 
 
 ceres::Solver::Options BundleAdjuster::SetUpSolverOptions(

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -70,8 +70,17 @@ struct BundleAdjustmentOptions {
   // Whether to fix the coordinate system.
   bool fix_coord_system = false;
 
-  // Whether to fix the global coordinate system.
-  bool fix_global_coord_system = false;
+  // Whether to add pose constraint between sequential images.
+  bool sequential_pairwise_constraint = false;
+
+  // Whether to add translation constraint between sequential images.
+  bool sequential_translation_constraint = false;
+  
+  // Weight for the translation constraint. 
+  double sequential_translation_weight = 1.0;
+  
+  // Weight for the rotation constraint.
+  double sequential_rotation_weight = 1.0;
 
   // Whether to print a final summary.
   bool print_summary = true;
@@ -246,6 +255,59 @@ class BundleAdjuster {
     const double distance_;
   };
 
+  // Vector difference constraint between two camera positions
+  struct VectorDifferenceConstraint {
+    VectorDifferenceConstraint(const Eigen::Vector3d& expected_diff, 
+                             const double weight)
+        : expected_diff_(expected_diff), weight_(weight) {}
+
+    template <typename T>
+    bool operator()(const T* const x1, const T* const x2, T* residuals) const {
+        for (size_t i = 0; i < 3; ++i) {
+            residuals[i] = weight_ * (x2[i] - x1[i] - T(expected_diff_[i]));
+        }
+        return true;
+    }
+
+    const Eigen::Vector3d expected_diff_;
+    const double weight_;
+};
+
+  // Cost function that enforces a relative rotation between two cameras
+  struct RelativeRotationConstraint {
+    explicit RelativeRotationConstraint(const Eigen::Quaterniond& relative_rotation)
+        : relative_rotation_(relative_rotation) {}
+
+    template <typename T>
+    bool operator()(const T* const qvec1, const T* const qvec2, T* residuals) const {
+        const Eigen::Quaternion<T> q1(qvec1[0], qvec1[1], qvec1[2], qvec1[3]);
+        const Eigen::Quaternion<T> q2(qvec2[0], qvec2[1], qvec2[2], qvec2[3]);
+
+        // Convert target relative rotation to template type
+        const Eigen::Quaternion<T> target_relative_rotation(
+            T(relative_rotation_.w()),
+            T(relative_rotation_.x()),
+            T(relative_rotation_.y()),
+            T(relative_rotation_.z()));
+
+        // Compute the current relative rotation
+        const Eigen::Quaternion<T> current_relative_rotation = q2 * q1.inverse();
+
+        // Compute the error quaternion between target and current relative rotations
+        const Eigen::Quaternion<T> error = target_relative_rotation.inverse() * current_relative_rotation;
+
+        // Use the vector part of the quaternion as the residual
+        // This represents the rotation error in a compact form
+        residuals[0] = error.x();
+        residuals[1] = error.y();
+        residuals[2] = error.z();
+
+        return true;
+    }
+
+    const Eigen::Quaterniond relative_rotation_;
+  };
+
   // 首先定義一個位置約束的 cost function
   struct PositionPriorConstraint {
       PositionPriorConstraint(const Eigen::Vector3d& prior_position, double weight)
@@ -272,7 +334,9 @@ class BundleAdjuster {
 
   void AddCoordinateSystemConstraint(Reconstruction* reconstruction);
 
-  void AddGlobalCoordinateSystemConstraint(Reconstruction* reconstruction);
+  void AddSequentialPairwisePoseConstraint(Reconstruction* reconstruction);
+
+  void AddSequentialTranslationConstraint(Reconstruction* reconstruction);
 
   void AddPositionPriorConstraints(Reconstruction* reconstruction);
 

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -290,11 +290,11 @@ class BundleAdjuster {
             T(relative_rotation_.y()),
             T(relative_rotation_.z()));
 
-        // Compute the current relative rotation
-        const Eigen::Quaternion<T> current_relative_rotation = q2 * q1.inverse();
+        // Compute the current relative rotation and normalize
+        const Eigen::Quaternion<T> current_relative_rotation = (q2 * q1.inverse()).normalized();
 
         // Compute the error quaternion between target and current relative rotations
-        const Eigen::Quaternion<T> error = target_relative_rotation.inverse() * current_relative_rotation;
+        const Eigen::Quaternion<T> error = (target_relative_rotation.inverse() * current_relative_rotation).normalized();
 
         // Use the vector part of the quaternion as the residual
         // This represents the rotation error in a compact form

--- a/src/colmap/estimators/bundle_adjustment.h
+++ b/src/colmap/estimators/bundle_adjustment.h
@@ -70,6 +70,9 @@ struct BundleAdjustmentOptions {
   // Whether to fix the coordinate system.
   bool fix_coord_system = false;
 
+  // Whether to fix the global coordinate system.
+  bool fix_global_coord_system = false;
+
   // Whether to print a final summary.
   bool print_summary = true;
 
@@ -268,6 +271,8 @@ class BundleAdjuster {
   };
 
   void AddCoordinateSystemConstraint(Reconstruction* reconstruction);
+
+  void AddGlobalCoordinateSystemConstraint(Reconstruction* reconstruction);
 
   void AddPositionPriorConstraints(Reconstruction* reconstruction);
 


### PR DESCRIPTION
**Context:**

argument `fix_coord_system` in `colmap/estimators/bundle_adjusment.cc` only triggers distance constraint to first two cameras, which is not robust enough. 

**Changes**

add a new argument `fix_global_coord_system` to `colmap/estimators/bundle_adjusment.cc` to trigger distance constraint  to every image pair sequentially.